### PR TITLE
added support of --help (-h) options

### DIFF
--- a/dcos_kafka/cli.py
+++ b/dcos_kafka/cli.py
@@ -95,7 +95,7 @@ class CliError(Exception): pass
 def main():
     args = sys.argv[2:] # remove dcos-kafka & kafka
     if len(args) == 1 and args[0] == "--info":
-        print("Manage Kafka brokers")
+        print("Start and manage Kafka brokers")
         return 0
 
     if len(args) == 1 and args[0] == "--version":
@@ -105,6 +105,11 @@ def main():
     if len(args) == 1 and args[0] == "--config-schema":
         print("{}")
         return 0
+
+    if "--help" in args or "-h" in args:
+        if "--help" in args: args.remove("--help")
+        if "-h" in args: args.remove("-h")
+        args.insert(0, "help")
 
     try:
         return run(args)


### PR DESCRIPTION
Hi. 

On behalf of https://github.com/mesos/kafka/issues/39 
I've added support for --help option on the python script's side.

Also I've modified Scala CLI to print more "dcos-compatible" generic help like this:
```
#dcos kafka --help
Usage: <command>

Commands:
  help {cmd} - print general or command-specific help
  status     - print cluster status
  add        - add brokers
  update     - update brokers
  remove     - remove brokers
  start      - start brokers
  stop       - stop brokers
  rebalance  - rebalance topics
```
Please review and merge. 
