### PR TITLE
Ben's patch to use router for communicating with kafka-scheduler

### DIFF
--- a/dcos_kafka/cli.py
+++ b/dcos_kafka/cli.py
@@ -2,11 +2,10 @@
 from __future__ import print_function
 import os
 import pkg_resources
-import requests
 import sys
 import subprocess
-import toml
-from dcos import marathon
+import urlparse
+from dcos import marathon, util
 from dcos_kafka import constants
 
 
@@ -17,8 +16,8 @@ def api_url():
     if len(tasks) == 0:
         raise CliError("Kafka is not running")
 
-    task = tasks[0]
-    return "http://" + task["host"] + ":" + str(task["ports"][0])
+    base_url = util.get_config().get('core.dcos_url')
+    return urlparse.urljoin(base_url, '/service/kafka/')
 
 
 def find_java():
@@ -73,7 +72,6 @@ class CliError(Exception): pass
 
 
 def main():
-    print(sys.argv)
     args = sys.argv[2:] # remove dcos-kafka & kafka
     if len(args) == 1 and args[0] == "--info":
         print("Start and manage Kafka brokers")

--- a/dcos_kafka/cli.py
+++ b/dcos_kafka/cli.py
@@ -1,9 +1,11 @@
 """DCOS Kafka"""
 from __future__ import print_function
+
 import os
-import pkg_resources
-import sys
 import subprocess
+import sys
+
+import pkg_resources
 from dcos import marathon, util
 from dcos_kafka import constants
 

--- a/dcos_kafka/cli.py
+++ b/dcos_kafka/cli.py
@@ -4,7 +4,6 @@ import os
 import pkg_resources
 import sys
 import subprocess
-import urlparse
 from dcos import marathon, util
 from dcos_kafka import constants
 
@@ -16,8 +15,8 @@ def api_url():
     if len(tasks) == 0:
         raise CliError("Kafka is not running")
 
-    base_url = util.get_config().get('core.dcos_url')
-    return urlparse.urljoin(base_url, '/service/kafka/')
+    base_url = util.get_config().get('core.dcos_url').rstrip("/")
+    return base_url + '/service/kafka/'
 
 
 def find_java():

--- a/dcos_kafka/cli.py
+++ b/dcos_kafka/cli.py
@@ -33,9 +33,12 @@ def find_java():
         for path in os.environ['PATH'].split(os.pathsep):
             path = path.strip('"')
             java_file = os.path.join(path, 'java')
-            if executable(java_file): return java_file
 
-    raise CliError("This command requires Java to be installed. Please install JRE")
+            if executable(java_file):
+                return java_file
+
+    raise CliError("This command requires Java to be installed. "
+                   "Please install JRE")
 
 
 def find_jar():
@@ -47,14 +50,16 @@ def find_jar():
 
 
 def run(args):
-    help = len(args) > 0 and args[0] == "help"
-    if help: args[0] = "help"
+    help_arg = len(args) > 0 and args[0] == "help"
+    if help_arg:
+        args[0] = "help"
 
     command = [find_java(), "-jar", find_jar()]
     command.extend(args)
 
-    env = {"KM_NO_SCHEDULER" : "true"}
-    if not help: env["KM_API"] = api_url()
+    env = {"KM_NO_SCHEDULER": "true"}
+    if not help_arg:
+        env["KM_API"] = api_url()
 
     process = subprocess.Popen(
         command,
@@ -69,11 +74,12 @@ def run(args):
     return process.returncode
 
 
-class CliError(Exception): pass
+class CliError(Exception):
+    pass
 
 
 def main():
-    args = sys.argv[2:] # remove dcos-kafka & kafka
+    args = sys.argv[2:]  # remove dcos-kafka & kafka
     if len(args) == 1 and args[0] == "--info":
         print("Start and manage Kafka brokers")
         return 0
@@ -87,8 +93,12 @@ def main():
         return 0
 
     if "--help" in args or "-h" in args:
-        if "--help" in args: args.remove("--help")
-        if "-h" in args: args.remove("-h")
+        if "--help" in args:
+            args.remove("--help")
+
+        if "-h" in args:
+            args.remove("-h")
+
         args.insert(0, "help")
 
     try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 requests
 toml
-sphinx
-tox
-wheel
+sphinx>=1.3.1, <2.0
+tox>=1.9.2, <2.0
+wheel>=0.24.0, <1.0

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,8 @@ setup(
         'dcos>=0.1.6, <1.0',
         'docopt',
         'toml',
-        'requests'
+        'requests',
+        'six>=1.9, <2.0'
     ],
 
     # List additional groups of dependencies here (e.g. development

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -6,5 +6,5 @@ def test_help():
         ['dcos-kafka', 'kafka', 'help'])
 
     assert returncode == 0
-    assert stdout.startswith("Usage:")
+    assert stdout.startswith(b"Usage:")
     assert stderr == b''

--- a/tests/integration/test_cli.py
+++ b/tests/integration/test_cli.py
@@ -8,4 +8,3 @@ def test_help():
     assert returncode == 0
     assert stdout.startswith("Usage:")
     assert stderr == b''
-


### PR DESCRIPTION
Hey, 

I've fixed a patch to be working.
I've tested against http://benw-13-elasticloa-1py8q8fyiw6li-1399817560.us-west-2.elb.amazonaws.com/
DCOS cluster using new CLI. 

dcos kafka status gots 500.
when going directly to http://benw-13-elasticloa-1py8q8fyiw6li-1399817560.us-west-2.elb.amazonaws.com/service/kafka/ I also got 500 for any suburl.

It reams that API Proxy has some problem.
Please __do not merge__ until retested.